### PR TITLE
send the whole params object to have access to query string data

### DIFF
--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::WebhooksController < Api::V1::BaseController
   end
 
   def register
-    Keen.publish(provider, params[:webhook])
+    Keen.publish(provider, params)
     respond_with({ status: "ok", service: provider })
   end
 
@@ -16,5 +16,4 @@ class Api::V1::WebhooksController < Api::V1::BaseController
   def provider
     @provider ||= params[:provider]
   end
-
 end


### PR DESCRIPTION
in toggl we don't have the name of the user, in zappier the POST has a query string `username=<username>` that we can use now
